### PR TITLE
Clarify that Buildstream 1.x is now EOL

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -27,8 +27,7 @@ Some key capabilities of BuildStream include:
 
 ## Apache BuildStream 2 is now available
 
-BuildStream 2 has been released and effectively replaces BuildStream 1, which is
-now in maintenance mode and will no longer be actively developed.
+BuildStream 2 has been released and replaces BuildStream 1, which is now end-of-life, and no longer works with Python greater than Python 3.11.x.
 
 Users are encouraged to follow the [porting guide](https://docs.buildstream.build/master/main_porting.html)
 to port their projects to the new API, and distributions are encouraged to ship

--- a/content/pages/installation.md
+++ b/content/pages/installation.md
@@ -17,8 +17,7 @@ There are two major versions of BuildStream currently supported.
 **Apache BuildStream 2** is the latest version, stable since 2022 and
 recommended for all new projects.
 
-**BuildStream 1** is the "classic taste" version, stable and supported
-since 2018. No new feature development is planned for BuildStream 1.
+**BuildStream 1** is end-of-life, and will not work on systems with a Python interpreter greater than 3.11.x.
 
 If you want to build a specific project, check its `project.conf` file for the
 [`min-version` setting](https://docs.buildstream.build/master/format_project.html#minimum-version).


### PR DESCRIPTION
Closes #6.